### PR TITLE
Stop engine and close when no active states exist

### DIFF
--- a/src/main/java/org/ois/core/runner/SimulationEngine.java
+++ b/src/main/java/org/ois/core/runner/SimulationEngine.java
@@ -126,6 +126,9 @@ public class SimulationEngine extends ApplicationAdapter {
             }
             if (stateManager.update(dt)) {
                 stateManager.render();
+            } else {
+                // No Active states
+                stop();
             }
         } catch (Exception e) {
             handleProgramException(e);


### PR DESCRIPTION
- [ ] All [tests](https://github.com/attiasas/ois-core/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] If this feature effect users, update the [documentation](../README.md) and the [wiki](https://github.com/attiasas/ois-core/wiki)
- [ ] This feature was validated on all supported platforms 
-----

The engine did not stop when no active state exists, resulting in nothing running/updating (freeze on last frame) and applicating not closing