### PR TITLE
Handle error if stateStack is empty

### DIFF
--- a/src/main/java/org/ois/core/state/StateManager.java
+++ b/src/main/java/org/ois/core/state/StateManager.java
@@ -243,6 +243,9 @@ public class StateManager {
      * @throws Exception if the exception is not handled by the state
      */
     private void handleCurrentStateException(String topic, Exception e) throws Exception {
+        if (this.stateStack.isEmpty()) {
+            throw e;
+        }
         String outState = this.stateStack.peek();
         String msg = "[" + topic + "] Caught exception from the current state '" + outState + "'";
         this.stateStack.pop();

--- a/src/main/java/org/ois/core/state/StateManager.java
+++ b/src/main/java/org/ois/core/state/StateManager.java
@@ -244,6 +244,7 @@ public class StateManager {
      */
     private void handleCurrentStateException(String topic, Exception e) throws Exception {
         if (this.stateStack.isEmpty()) {
+            // If error caught when entering a single state, the state is not current and stack is empty
             throw e;
         }
         String outState = this.stateStack.peek();


### PR DESCRIPTION
- [ ] All [tests](https://github.com/attiasas/ois-core/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] If this feature effect users, update the [documentation](../README.md) and the [wiki](https://github.com/attiasas/ois-core/wiki)
- [ ] This feature was validated on all supported platforms 
-----

If error caught when entering a single state, the state is not current and stack is empty
we get `EmptyStackException` not showing the actual `Exception`
Before:
![image](https://github.com/user-attachments/assets/b2bfebe4-692d-47b5-ab26-a67294ec53a4)

After:
![image](https://github.com/user-attachments/assets/31d28081-8032-4a1c-b9d5-77de3d70637c)
