### PR TITLE
State queue

### DIFF
--- a/src/main/java/org/ois/core/state/StateManager.java
+++ b/src/main/java/org/ois/core/state/StateManager.java
@@ -66,6 +66,10 @@ public class StateManager {
         if (key == null || !this.states.containsKey(key)) {
             throw new IllegalArgumentException("Can't find state '" + key + "' in the registered states.");
         }
+        if (key.equals(getCurrentStateKey())) {
+            // The current state is the key that requesting to change, no need to change
+            return;
+        }
         nextState = key;
         nextStateParams = params;
     }
@@ -283,6 +287,18 @@ public class StateManager {
             return null;
         }
         return this.states.get(this.stateStack.peek());
+    }
+
+    /**
+     * Returns the current active state key.
+     *
+     * @return the current state key, or null if no active state exists
+     */
+    public String getCurrentStateKey() {
+        if (!hasActiveState()) {
+            return null;
+        }
+        return this.stateStack.peek();
     }
 
     /**

--- a/src/main/java/org/ois/core/state/StateManager.java
+++ b/src/main/java/org/ois/core/state/StateManager.java
@@ -21,6 +21,9 @@ public class StateManager {
     /** Active state stack by keys **/
     private final Stack<String> stateStack = new Stack<>();
 
+    private String nextState;
+    private Object[] nextStateParams;
+
     // Container management
 
     /**
@@ -63,10 +66,22 @@ public class StateManager {
         if (key == null || !this.states.containsKey(key)) {
             throw new IllegalArgumentException("Can't find state '" + key + "' in the registered states.");
         }
+        nextState = key;
+        nextStateParams = params;
+    }
+
+    private void changeToNextState() {
+        if (nextState == null) {
+            // Change state was not requested
+            return;
+        }
         while (hasActiveState()) {
             exitCurrentState();
         }
-        enterState(key, params);
+        enterState(nextState, nextStateParams);
+        // Reset
+        nextState = null;
+        nextStateParams = null;
     }
 
     /**
@@ -125,6 +140,9 @@ public class StateManager {
      * @throws Exception if an error occurs during the state update
      */
     public boolean update(float delta) throws Exception {
+        // Change states if needed
+        changeToNextState();
+        // Get current
         IState current = getCurrentState();
         if (current == null) {
             return false;

--- a/src/test/java/org/ois/core/runner/SimulationEngineTest.java
+++ b/src/test/java/org/ois/core/runner/SimulationEngineTest.java
@@ -54,6 +54,9 @@ public class SimulationEngineTest {
         engine.create();
         // Check if the states are loaded
         Assert.assertTrue(engine.stateManager.states().contains("state1"), "State 'state1' should be loaded.");
+        // Load only takes affect after update
+        Assert.assertNull(engine.stateManager.getCurrentState());
+        Assert.assertTrue(engine.stateManager.update(0));
         // Make sure it was created with reflection and entered the state
         Assert.assertTrue(((ErrorState)engine.stateManager.getCurrentState()).isActive());
     }
@@ -87,6 +90,13 @@ public class SimulationEngineTest {
 
         engine.create();
 
+        // Load only takes affect after update
+        Assert.assertNull(engine.stateManager.getCurrentState());
+        try {
+            Assert.assertTrue(engine.stateManager.update(0));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         MockState currentState = (MockState) engine.stateManager.getCurrentState();
         currentState.throwErr = true;
 
@@ -102,6 +112,14 @@ public class SimulationEngineTest {
         engine.stateManager.registerState("mockState", new MockState());
         engine.stateManager.start("mockState");
 
+        // Load only takes affect after update
+        Assert.assertNull(engine.stateManager.getCurrentState());
+        try {
+            Assert.assertTrue(engine.stateManager.update(0));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
         engine.resize(800, 600); // Resize without error state
         Assert.assertFalse(engine.errorState.isActive(), "ErrorState should not be active during resize without an exception.");
 
@@ -115,6 +133,14 @@ public class SimulationEngineTest {
         // Test that dispose is called on both the state manager and error state
         engine.stateManager.registerState("mockState", new MockState());
         engine.stateManager.start("mockState");
+
+        // Load only takes affect after update
+        Assert.assertNull(engine.stateManager.getCurrentState());
+        try {
+            Assert.assertTrue(engine.stateManager.update(0));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         engine.dispose();
         Assert.assertFalse(engine.errorState.isActive(), "ErrorState should be disposed and inactive.");


### PR DESCRIPTION
- [ ] All [tests](https://github.com/attiasas/ois-core/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] If this feature effect users, update the [documentation](../README.md) and the [wiki](https://github.com/attiasas/ois-core/wiki)
- [ ] This feature was validated on all supported platforms 
-----

Bug fixes related to StateManager:
* Only change the state on the start of `update` method, to avoid rendering the new state after update (usually changed there)
* Don't enter and exit a state if its already the active one