### PR TITLE
DataNode Properties and more

### DIFF
--- a/src/main/java/org/ois/core/entities/EntityManager.java
+++ b/src/main/java/org/ois/core/entities/EntityManager.java
@@ -6,7 +6,7 @@ import org.ois.core.project.Entities;
 import org.ois.core.utils.ID;
 import org.ois.core.utils.io.data.Blueprint;
 import org.ois.core.utils.io.data.DataNode;
-import org.ois.core.utils.io.data.DataObject;
+import org.ois.core.utils.io.data.IDataObject;
 
 import java.util.*;
 
@@ -14,7 +14,7 @@ import java.util.*;
  * Manages the creation, storage, and lifecycle of {@link Entity} instances.
  * It supports entity retrieval, removal, and periodic updates.
  */
-public class EntityManager implements DataObject<EntityManager>, Disposable {
+public class EntityManager implements IDataObject<EntityManager>, Disposable {
 
     /** Stores entities categorized by their type and ID. */
     Map<String, Map<ID, Entity>> entities = new Hashtable<>();
@@ -81,7 +81,7 @@ public class EntityManager implements DataObject<EntityManager>, Disposable {
         if (!data.contains(Entities.TYPE_PROPERTY)) {
             throw new RuntimeException(String.format("can't create Entity: '%s' property not provided", Entities.TYPE_PROPERTY));
         }
-        return create(data.get(Entities.TYPE_PROPERTY).getString()).loadData(data);
+        return (Entity) create(data.get(Entities.TYPE_PROPERTY).getString()).loadData(data);
     }
 
     /**

--- a/src/main/java/org/ois/core/project/SimulationManifest.java
+++ b/src/main/java/org/ois/core/project/SimulationManifest.java
@@ -2,7 +2,7 @@ package org.ois.core.project;
 
 import org.ois.core.runner.RunnerConfiguration;
 import org.ois.core.utils.io.data.DataNode;
-import org.ois.core.utils.io.data.DataObject;
+import org.ois.core.utils.io.data.IDataObject;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 /**
  * Represents the Simulation Manifest, used by the project to configure how the project simulation is set up.
  */
-public class SimulationManifest implements DataObject<SimulationManifest> {
+public class SimulationManifest implements IDataObject<SimulationManifest> {
     /** The default name of the project configuration file that will be searched at the root project **/
     public static final String DEFAULT_FILE_NAME = "simulation.ois";
     /** The title of the project **/

--- a/src/main/java/org/ois/core/state/managed/ManagedState.java
+++ b/src/main/java/org/ois/core/state/managed/ManagedState.java
@@ -2,9 +2,9 @@ package org.ois.core.state.managed;
 
 import org.ois.core.entities.EntityManager;
 import org.ois.core.utils.io.data.DataNode;
-import org.ois.core.utils.io.data.DataObject;
+import org.ois.core.utils.io.data.IDataObject;
 
-public abstract class ManagedState implements IManagedState, DataObject<ManagedState> {
+public abstract class ManagedState implements IManagedState, IDataObject<ManagedState> {
 
     protected EntityManager entityManager;
 

--- a/src/main/java/org/ois/core/utils/io/data/Blueprint.java
+++ b/src/main/java/org/ois/core/utils/io/data/Blueprint.java
@@ -1,6 +1,6 @@
 package org.ois.core.utils.io.data;
 
 
-public interface Blueprint<T> extends DataObject<Blueprint<T>> {
+public interface Blueprint<T> extends IDataObject<Blueprint<T>> {
     T create();
 }

--- a/src/main/java/org/ois/core/utils/io/data/DataNode.java
+++ b/src/main/java/org/ois/core/utils/io/data/DataNode.java
@@ -895,6 +895,13 @@ public class DataNode implements Iterable<DataNode> {
         return copy;
     }
 
+    public DataNode removeAttributes(String ...attributes) {
+        for (String attribute : attributes) {
+            this.attributes.remove(attribute);
+        }
+        return this;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(nodeType, value, content, attributes);

--- a/src/main/java/org/ois/core/utils/io/data/DataObject.java
+++ b/src/main/java/org/ois/core/utils/io/data/DataObject.java
@@ -9,21 +9,17 @@ public class DataObject implements IDataObject<DataObject> {
 
     List<Property> managedProperties = new ArrayList<>();
 
-    public <T extends Property> T registerProperty(T property) {
+    public <P extends Property> P registerProperty(P property) {
         managedProperties.add(property);
         return property;
     }
 
-    public <T extends DataObject> T loadObject(DataNode dataNode) {
-        return (T) loadData(dataNode);
-    }
-
     @Override
-    public DataObject loadData(DataNode dataNode) {
+    public <T extends DataObject> T loadData(DataNode dataNode) {
         for (Property property : managedProperties) {
             property.loadData(dataNode);
         }
-        return this;
+        return (T) this;
     }
 
     @Override

--- a/src/main/java/org/ois/core/utils/io/data/DataObject.java
+++ b/src/main/java/org/ois/core/utils/io/data/DataObject.java
@@ -1,24 +1,37 @@
 package org.ois.core.utils.io.data;
 
-/**
- * Interface representing a data object that can load data from a {@link DataNode}
- * and convert itself to a {@link DataNode}.
- *
- * @param <T> the type of the data object
- */
-public interface DataObject<T> {
-    /**
-     * Loads data from the specified {@link DataNode} and populates the data object.
-     *
-     * @param data the {@link DataNode} containing the data to be loaded
-     * @return the populated data object
-     */
-    T loadData(DataNode data);
+import org.ois.core.utils.io.data.properties.Property;
 
-    /**
-     * Converts the data object to a {@link DataNode} representation.
-     *
-     * @return the {@link DataNode} representing the data object
-     */
-    DataNode convertToDataNode();
+import java.util.ArrayList;
+import java.util.List;
+
+public class DataObject implements IDataObject<DataObject> {
+
+    List<Property> managedProperties = new ArrayList<>();
+
+    public <T extends Property> T registerProperty(T property) {
+        managedProperties.add(property);
+        return property;
+    }
+
+    public <T extends DataObject> T loadObject(DataNode dataNode) {
+        return (T) loadData(dataNode);
+    }
+
+    @Override
+    public DataObject loadData(DataNode dataNode) {
+        for (Property property : managedProperties) {
+            property.loadData(dataNode);
+        }
+        return this;
+    }
+
+    @Override
+    public DataNode convertToDataNode() {
+        DataNode root = new DataNode();
+        for (Property property : managedProperties) {
+            property.appendPropertyToDataNode(root);
+        }
+        return root;
+    }
 }

--- a/src/main/java/org/ois/core/utils/io/data/IDataObject.java
+++ b/src/main/java/org/ois/core/utils/io/data/IDataObject.java
@@ -1,0 +1,24 @@
+package org.ois.core.utils.io.data;
+
+/**
+ * Interface representing a data object that can load data from a {@link DataNode}
+ * and convert itself to a {@link DataNode}.
+ *
+ * @param <T> the type of the data object
+ */
+public interface IDataObject<T> {
+    /**
+     * Loads data from the specified {@link DataNode} and populates the data object.
+     *
+     * @param data the {@link DataNode} containing the data to be loaded
+     * @return the populated data object
+     */
+    T loadData(DataNode data);
+
+    /**
+     * Converts the data object to a {@link DataNode} representation.
+     *
+     * @return the {@link DataNode} representing the data object
+     */
+    DataNode convertToDataNode();
+}

--- a/src/main/java/org/ois/core/utils/io/data/IDataObject.java
+++ b/src/main/java/org/ois/core/utils/io/data/IDataObject.java
@@ -13,7 +13,7 @@ public interface IDataObject<T> {
      * @param data the {@link DataNode} containing the data to be loaded
      * @return the populated data object
      */
-    T loadData(DataNode data);
+    <D extends T> D loadData(DataNode data);
 
     /**
      * Converts the data object to a {@link DataNode} representation.

--- a/src/main/java/org/ois/core/utils/io/data/formats/DataFormat.java
+++ b/src/main/java/org/ois/core/utils/io/data/formats/DataFormat.java
@@ -1,13 +1,13 @@
 package org.ois.core.utils.io.data.formats;
 
 import org.ois.core.utils.io.data.DataNode;
-import org.ois.core.utils.io.data.DataObject;
+import org.ois.core.utils.io.data.IDataObject;
 
 import java.io.*;
 
 /**
  * Interface for defining data formats for serialization and deserialization
- * of {@link DataNode} and {@link DataObject} instances.
+ * of {@link DataNode} and {@link IDataObject} instances.
  */
 public interface DataFormat {
 
@@ -28,13 +28,13 @@ public interface DataFormat {
     String serialize(DataNode data);
 
     /**
-     * Serializes a {@link DataObject} into its string representation
+     * Serializes a {@link IDataObject} into its string representation
      * by first converting it to a {@link DataNode}.
      *
-     * @param data the {@link DataObject} to be serialized
+     * @param data the {@link IDataObject} to be serialized
      * @return the string representation of the serialized data
      */
-    default String serialize(DataObject<?> data) {
+    default String serialize(IDataObject<?> data) {
         return serialize(data.convertToDataNode());
     }
 
@@ -57,39 +57,39 @@ public interface DataFormat {
     }
 
     /**
-     * Loads data from an {@link InputStream} into the specified {@link DataObject}.
+     * Loads data from an {@link InputStream} into the specified {@link IDataObject}.
      *
-     * @param objToLoad the {@link DataObject} to populate with data
+     * @param objToLoad the {@link IDataObject} to populate with data
      * @param inputStream the input stream containing the data
      * @param <T> the type of the data object
-     * @return the populated {@link DataObject}
+     * @return the populated {@link IDataObject}
      * @throws IOException if an I/O error occurs while reading the stream
      */
-    default <T extends DataObject<T>> T load(T objToLoad, InputStream inputStream) throws IOException {
+    default <T extends IDataObject<T>> T load(T objToLoad, InputStream inputStream) throws IOException {
         return objToLoad.loadData(load(inputStream));
     }
 
     /**
-     * Loads data from a byte array into the specified {@link DataObject}.
+     * Loads data from a byte array into the specified {@link IDataObject}.
      *
-     * @param objToLoad the {@link DataObject} to populate with data
+     * @param objToLoad the {@link IDataObject} to populate with data
      * @param source the byte array containing the data
      * @param <T> the type of the data object
-     * @return the populated {@link DataObject}
+     * @return the populated {@link IDataObject}
      */
-    default <T extends DataObject<T>> T load(T objToLoad, byte[] source) {
+    default <T extends IDataObject<T>> T load(T objToLoad, byte[] source) {
         return load(objToLoad, new String(source));
     }
 
     /**
-     * Loads data from a string into the specified {@link DataObject}.
+     * Loads data from a string into the specified {@link IDataObject}.
      *
-     * @param objToLoad the {@link DataObject} to populate with data
+     * @param objToLoad the {@link IDataObject} to populate with data
      * @param source the string containing the data
      * @param <T> the type of the data object
-     * @return the populated {@link DataObject}
+     * @return the populated {@link IDataObject}
      */
-    default <T extends DataObject<T>> T load(T objToLoad, String source) {
+    default <T extends IDataObject<T>> T load(T objToLoad, String source) {
         return objToLoad.loadData(deserialize(source));
     }
 }

--- a/src/main/java/org/ois/core/utils/io/data/properties/BooleanProperty.java
+++ b/src/main/java/org/ois/core/utils/io/data/properties/BooleanProperty.java
@@ -1,0 +1,27 @@
+package org.ois.core.utils.io.data.properties;
+
+import org.ois.core.utils.io.data.DataNode;
+
+public class BooleanProperty extends Property<Boolean> {
+
+    public BooleanProperty(String key) {
+        super(key);
+    }
+
+    @Override
+    public Boolean loadProperty(DataNode attributeValue) {
+        managedData = attributeValue.getBoolean();
+        return managedData;
+    }
+
+    @Override
+    public DataNode appendProperty(DataNode root) {
+        root.set(this.key, managedData);
+        return root;
+    }
+
+    @Override
+    public DataNode convertToDataNode() {
+        return DataNode.Primitive(managedData);
+    }
+}

--- a/src/main/java/org/ois/core/utils/io/data/properties/DataProperty.java
+++ b/src/main/java/org/ois/core/utils/io/data/properties/DataProperty.java
@@ -1,0 +1,33 @@
+package org.ois.core.utils.io.data.properties;
+
+import org.ois.core.utils.io.data.DataNode;
+import org.ois.core.utils.io.data.IDataObject;
+
+public class DataProperty<T extends IDataObject<T>> extends Property<T> {
+
+    public DataProperty(String key) {
+        super(key);
+    }
+
+    @Override
+    public T loadProperty(DataNode attributeValue) {
+        if (managedData == null) {
+            throw new RuntimeException("can't load DataObject property if managed data is null, set default value or optional");
+        }
+        return managedData.loadData(attributeValue);
+    }
+
+    @Override
+    public DataNode appendProperty(DataNode root) {
+        if (managedData == null && optional) {
+            return root;
+        }
+        root.set(this.key, convertToDataNode());
+        return root;
+    }
+
+    @Override
+    public DataNode convertToDataNode() {
+        return managedData == null ? DataNode.Object() : managedData.convertToDataNode();
+    }
+}

--- a/src/main/java/org/ois/core/utils/io/data/properties/FloatProperty.java
+++ b/src/main/java/org/ois/core/utils/io/data/properties/FloatProperty.java
@@ -1,0 +1,26 @@
+package org.ois.core.utils.io.data.properties;
+
+import org.ois.core.utils.io.data.DataNode;
+
+public class FloatProperty extends Property<Float> {
+    public FloatProperty(String key) {
+        super(key);
+    }
+
+    @Override
+    public Float loadProperty(DataNode attributeValue) {
+        managedData = attributeValue.getFloat();
+        return managedData;
+    }
+
+    @Override
+    public DataNode appendProperty(DataNode root) {
+        root.set(this.key, managedData);
+        return root;
+    }
+
+    @Override
+    public DataNode convertToDataNode() {
+        return DataNode.Primitive(managedData);
+    }
+}

--- a/src/main/java/org/ois/core/utils/io/data/properties/IntProperty.java
+++ b/src/main/java/org/ois/core/utils/io/data/properties/IntProperty.java
@@ -1,0 +1,26 @@
+package org.ois.core.utils.io.data.properties;
+
+import org.ois.core.utils.io.data.DataNode;
+
+public class IntProperty extends Property<Integer> {
+    public IntProperty(String key) {
+        super(key);
+    }
+
+    @Override
+    public Integer loadProperty(DataNode attributeValue) {
+        managedData = attributeValue.getInt();
+        return managedData;
+    }
+
+    @Override
+    public DataNode appendProperty(DataNode root) {
+        root.set(this.key, managedData);
+        return root;
+    }
+
+    @Override
+    public DataNode convertToDataNode() {
+        return DataNode.Primitive(managedData);
+    }
+}

--- a/src/main/java/org/ois/core/utils/io/data/properties/Property.java
+++ b/src/main/java/org/ois/core/utils/io/data/properties/Property.java
@@ -31,6 +31,7 @@ public abstract class Property<T> implements IDataObject<T> {
     public Property<T> setDefaultValue(T defaultValue) {
         this.defaultValue = defaultValue;
         this.defaultSet = true;
+        this.managedData = defaultValue;
         return this;
     }
 
@@ -39,7 +40,7 @@ public abstract class Property<T> implements IDataObject<T> {
     }
 
     @Override
-    public T loadData(DataNode dataNode) {
+    public <D extends T> D loadData(DataNode dataNode) {
         if (!dataNode.contains(key)) {
             if (!optional) {
                 throw new RuntimeException(String.format("Can't load '%s' from data node: expected '%s' attribute", managedData.getClass().getName(), this.key));
@@ -47,9 +48,9 @@ public abstract class Property<T> implements IDataObject<T> {
             if (defaultSet) {
                 managedData = defaultValue;
             }
-            return managedData;
+            return (D) managedData;
         }
-        return loadProperty(dataNode.get(key));
+        return (D) loadProperty(dataNode.get(key));
     }
 
     public abstract T loadProperty(DataNode attributeValue);

--- a/src/main/java/org/ois/core/utils/io/data/properties/Property.java
+++ b/src/main/java/org/ois/core/utils/io/data/properties/Property.java
@@ -1,0 +1,70 @@
+package org.ois.core.utils.io.data.properties;
+
+import org.ois.core.utils.io.data.DataNode;
+import org.ois.core.utils.io.data.IDataObject;
+
+public abstract class Property<T> implements IDataObject<T> {
+
+    protected final String key;
+
+    protected T managedData;
+
+    private T defaultValue;
+    private boolean defaultSet;
+
+    protected boolean optional;
+
+    public Property(String key) {
+        this.key = key;
+    }
+
+    public Property<T> set(T data) {
+        this.managedData = data;
+        return this;
+    }
+
+    public Property<T> setOptional(boolean optional) {
+        this.optional = optional;
+        return this;
+    }
+
+    public Property<T> setDefaultValue(T defaultValue) {
+        this.defaultValue = defaultValue;
+        this.defaultSet = true;
+        return this;
+    }
+
+    public T get() {
+        return managedData;
+    }
+
+    @Override
+    public T loadData(DataNode dataNode) {
+        if (!dataNode.contains(key)) {
+            if (!optional) {
+                throw new RuntimeException(String.format("Can't load '%s' from data node: expected '%s' attribute", managedData.getClass().getName(), this.key));
+            }
+            if (defaultSet) {
+                managedData = defaultValue;
+            }
+            return managedData;
+        }
+        return loadProperty(dataNode.get(key));
+    }
+
+    public abstract T loadProperty(DataNode attributeValue);
+    public abstract DataNode appendProperty(DataNode root);
+
+    public DataNode appendPropertyToDataNode(DataNode root) {
+        if (optional && defaultSet && managedData == defaultValue) {
+            // No need to append optional default value
+            return root;
+        }
+        return appendProperty(root);
+    }
+
+    @Override
+    public String toString() {
+        return "'" + key + '\'' + ": " + managedData;
+    }
+}

--- a/src/main/java/org/ois/core/utils/io/data/properties/StringProperty.java
+++ b/src/main/java/org/ois/core/utils/io/data/properties/StringProperty.java
@@ -1,0 +1,26 @@
+package org.ois.core.utils.io.data.properties;
+
+import org.ois.core.utils.io.data.DataNode;
+
+public class StringProperty extends Property<String> {
+    public StringProperty(String key) {
+        super(key);
+    }
+
+    @Override
+    public String loadProperty(DataNode attributeValue) {
+        managedData = attributeValue.getString();
+        return managedData;
+    }
+
+    @Override
+    public DataNode appendProperty(DataNode root) {
+        root.set(this.key, managedData);
+        return root;
+    }
+
+    @Override
+    public DataNode convertToDataNode() {
+        return DataNode.Primitive(managedData);
+    }
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/attiasas/ois-core/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] If this feature effect users, update the [documentation](../README.mhttps://github.com/attiasas/ois-core/pull/10/filesd) and the [wiki](https://github.com/attiasas/ois-core/wiki)
- [ ] This feature was validated on all supported platforms 
-----

Adding `Property` object and `DataObject` that managed them allows to extend and register attributes to DataNode easier